### PR TITLE
Add whereNotNull to Iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `Iterable<E>.zipTo`
 - Add `Iterable<E>.zipToPairs`
 - Add `Pair<L, R>`
+- Add `Iterable<E>.whereNotNull`
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ just for human consumption.
 
   * `bracket` - add values at the beginning and end of an iterable
   * `interleave` - insert values between elements of an iterable
+  * `whereNotNull` - copy the iterable, removing `null`s
   * `zip` - zip two homogeneous lists into one list of lists
   * `zipTo` - zip two arbitrary lists into a list of arbitrary values
   * `zipToPairs` - zip two arbitrary lists into a list of `Pair`s

--- a/example/iterable_extensions_example.dart
+++ b/example/iterable_extensions_example.dart
@@ -20,4 +20,7 @@ void main() {
   print('[\'Kate\', \'Pablo\'].zipToPairs([28, 31])');
   print(['Kate', 'Pablo'].zipToPairs([28, 31]));
   print('');
+
+  print('[null, 1, null, 2, null].whereNotNull()');
+  print([null, 1, null, 2, null].whereNotNull());
 }

--- a/lib/src/iterable_extensions.dart
+++ b/lib/src/iterable_extensions.dart
@@ -38,6 +38,22 @@ extension IterableExtensions<E> on Iterable<E> {
     yield last;
   }
 
+  /// Return an iterable with any `null` elements removed.
+  ///
+  /// For example:
+  ///
+  /// [1, null, 2].whereNotNull() // [1, 2]
+  /// [1, 2].whereNotNull() // [1, 2]
+  /// [].whereNotNull() // []
+  Iterable<E> whereNotNull() sync* {
+    for (final element in this) {
+      if (element == null) {
+        continue;
+      }
+      yield element;
+    }
+  }
+
   /// Zip the elements of the iterable together with those of the
   /// given iterable to form an iterable of lists (of length two)
   /// of elements at the same indices as those of the inputs.

--- a/test/src/iterable_extensions_test.dart
+++ b/test/src/iterable_extensions_test.dart
@@ -56,6 +56,24 @@ void main() {
       });
     });
 
+    group('whereNotNull()', () {
+      test('should return an empty iterable when called on one', () {
+        expect([].whereNotNull(), hasLength(0));
+      });
+
+      test('should not change an iterable with no null elements', () {
+        final output = [1, 2].whereNotNull();
+        expect(output, hasLength(2));
+        expect(output, containsAllInOrder([1, 2]));
+      });
+
+      test('should remove null elements from an iterable', () {
+        final output = [null, 1, null, 2, null].whereNotNull();
+        expect(output, hasLength(2));
+        expect(output, containsAllInOrder([1, 2]));
+      });
+    });
+
     group('zip()', () {
       test('should return an empty list if both iterables are empty', () {
         expect([].zip([]), isEmpty);


### PR DESCRIPTION
I find myself removing `null`s from iterables a lot, and it's annoying. Amiright?